### PR TITLE
Database and admin menu boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Team:
 Alexander Eckert
 Cameron Showalter
+Rohan Weeden
 
 ### Guidelines
 

--- a/src/class.danceparty-admin.php
+++ b/src/class.danceparty-admin.php
@@ -17,7 +17,7 @@ class DancePartyAdmin
     }
 
     static function init_hooks() {
-        add_action( 'admin_menu', array( 'DancePartyAdmin', 'setup_menu') );
+        add_action( 'admin_menu', array( 'DancePartyAdmin', 'setup_menu' ) );
 
         self::$init_done = true;
     }
@@ -26,7 +26,7 @@ class DancePartyAdmin
         add_menu_page( DanceParty::NAME . ' Settings',
                        DanceParty::NAME, 'manage_options',
                        'danceparty-plugin',
-                       array('DancePartyAdmin', 'admin_view') );
+                       array('DancePartyAdmin', 'admin_view' ) );
     }
 
     static function admin_view() {

--- a/src/class.danceparty-admin.php
+++ b/src/class.danceparty-admin.php
@@ -18,15 +18,46 @@ class DancePartyAdmin
 
     static function init_hooks() {
         add_action( 'admin_menu', array( 'DancePartyAdmin', 'setup_menu' ) );
+        add_action( 'admin_init', array( 'DancePartyAdmin', 'register_settings' ) );
 
         self::$init_done = true;
     }
 
     static function setup_menu() {
-        add_menu_page( DanceParty::NAME . ' Settings',
-                       DanceParty::NAME, 'manage_options',
-                       'danceparty-plugin',
-                       array('DancePartyAdmin', 'admin_view' ) );
+        $page_title = DanceParty::NAME . ' Options';
+        $menu_title = DanceParty::NAME;
+        $capability = 'manage_options';
+        $menu_slug = 'danceparty-plugin';
+        $function = array( 'DancePartyAdmin', 'admin_view' );
+        add_menu_page( $page_title, $menu_title, $capability,
+                       $menu_slug, $function);
+    }
+
+    static function register_settings() {
+        $option_group = DanceParty::OPTION_GROUP;
+        $option_name = DanceParty::OPTION_GROUP . '-options';
+        register_setting( $option_group, $option_name );
+
+        $db_section = DanceParty::OPTION_GROUP . '-db';
+        add_settings_section(
+            $db_section,
+            'Database Options',
+            array( 'DancePartyAdmin', 'db_section' ),
+            $option_group
+        );
+
+        add_settings_field(
+            'db_host',
+            'Host',
+            array( 'DancePartyAdmin', 'db_host_field_html' ),
+            $option_group,
+            $db_section
+        );
+    }
+
+    static function db_section() {}
+    static function db_host_field_html() {
+        echo '<input id="db_host" name="db_host" type="text"/>';
     }
 
     static function admin_view() {

--- a/src/class.danceparty.php
+++ b/src/class.danceparty.php
@@ -8,6 +8,7 @@ require_once( DP_PLUGIN_DIR . 'class.router.php' );
 class DanceParty
 {
     const NAME = 'Dance Party';
+    const OPTION_GROUP = 'danceparty-options';
     const CONTROLLER_DIR = DP_PLUGIN_DIR . 'controllers/';
     const VIEW_DIR = DP_PLUGIN_DIR . 'views/';
 

--- a/src/controllers/index.php
+++ b/src/controllers/index.php
@@ -1,0 +1,2 @@
+<?php
+# Silence is golden

--- a/src/models/index.php
+++ b/src/models/index.php
@@ -1,0 +1,2 @@
+<?php
+# Silence is golden

--- a/src/models/pdo-repository.php
+++ b/src/models/pdo-repository.php
@@ -1,0 +1,20 @@
+<?php
+  abstract class PDORepository {
+    private $username = '';
+    private $password = '';
+    private $host = '';
+    private $name = '';
+
+    private function getConnection() {
+      $conn = new PDO("mysql:dbname=$name;host=$host", $username, $password);
+      return $conn;
+    }
+
+    protected function queryList($sql, $args) {
+      $conn = $this->getConnection();
+      $stmt = $conn->prepare($sql);
+      $stmt->execute($args);
+      return $stmt;
+    }
+  }
+?>

--- a/src/models/pdo-repository.php
+++ b/src/models/pdo-repository.php
@@ -1,20 +1,20 @@
 <?php
-  abstract class PDORepository {
-    private $username = '';
-    private $password = '';
-    private $host = '';
-    private $name = '';
+    abstract class PDORepository {
+        private $username = '';
+        private $password = '';
+        private $host = '';
+        private $name = '';
 
-    private function getConnection() {
-      $conn = new PDO("mysql:dbname=$name;host=$host", $username, $password);
-      return $conn;
-    }
+        private function getConnection() {
+            $conn = new PDO("mysql:dbname=$name;host=$host", $username, $password);
+            return $conn;
+        }
 
-    protected function queryList($sql, $args) {
-      $conn = $this->getConnection();
-      $stmt = $conn->prepare($sql);
-      $stmt->execute($args);
-      return $stmt;
+        protected function queryList($sql, $args) {
+            $conn = $this->getConnection();
+            $stmt = $conn->prepare($sql);
+            $stmt->execute($args);
+            return $stmt;
+        }
     }
-  }
 ?>

--- a/src/views/index.php
+++ b/src/views/index.php
@@ -1,0 +1,2 @@
+<?php
+# Silence is golden

--- a/src/views/plugin_admin.php
+++ b/src/views/plugin_admin.php
@@ -1,1 +1,12 @@
-<h1>Hello world again</h1>
+<div class="wrap">
+    <h1><?php echo DanceParty::NAME ?> Options</h1>
+
+    <form action="options.php" method="post">
+        <?php
+            settings_fields( DanceParty::OPTION_GROUP );
+            do_settings_sections( DanceParty::OPTION_GROUP );
+
+            submit_button();
+        ?>
+    </form>
+</div>


### PR DESCRIPTION
Messed around with the WordPress options API. After about an hour of Googling and reading tutorials, I decided it is probably not worth it. I suggest we skip the options and just do the POST argument parsing ourselves. It will be much, much easier.

-   [x] Code runs without errors
-   [x] App version number is correct
-   [ ] Relevant information is documented in the readme
